### PR TITLE
replace tabs with spaces

### DIFF
--- a/syntax/cabal.vim
+++ b/syntax/cabal.vim
@@ -11,12 +11,12 @@ elseif exists("b:current_syntax")
   finish
 endif
 
-syn match	cabalCategory	"\c\<executable\>"
-syn match	cabalCategory	"\c\<library\>"
-syn match	cabalCategory	"\c\<benchmark\>"
-syn match	cabalCategory	"\c\<test-suite\>"
-syn match	cabalCategory	"\c\<source-repository\>"
-syn match	cabalCategory	"\c\<flag\>"
+syn match       cabalCategory   "\c\<executable\>"
+syn match       cabalCategory   "\c\<library\>"
+syn match       cabalCategory   "\c\<benchmark\>"
+syn match       cabalCategory   "\c\<test-suite\>"
+syn match       cabalCategory   "\c\<source-repository\>"
+syn match       cabalCategory   "\c\<flag\>"
 
 syn keyword     cabalConditional    if else
 syn match       cabalOperator       "&&\|||\|!\|==\|>=\|<="
@@ -36,66 +36,66 @@ syn match       cabalCompiler   "\c\<helium\>"
 syn match       cabalCompiler   "\c\<jhc\>"
 syn match       cabalCompiler   "\c\<lhc\>"
 
-syn match	cabalStatement	/^\c\s*\<default-language\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<default-extensions\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<default-language\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<default-extensions\s*:/me=e-1
 
-syn match	cabalStatement	/^\c\s*\<author\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<branch\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<bug-reports\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<build-depends\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<build-tools\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<build-type\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<buildable\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<c-sources\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<cabal-version\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<category\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<cc-options\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<copyright\s*:/me=e-1
-syn match   cabalStatement  /^\c\s*\<cpp-options\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<data-dir\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<data-files\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<default\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<description\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<executable\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<exposed\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<exposed-modules\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<extensions\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<extra-lib-dirs\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<extra-libraries\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<extra-source-files\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<extra-doc-files\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<extra-tmp-files\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<for example\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<frameworks\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<ghc-options\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<ghc-prof-options\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<ghc-shared-options\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<homepage\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<hs-source-dirs\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<hugs-options\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<include-dirs\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<includes\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<install-includes\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<ld-options\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<license\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<license-file\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<location\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<main-is\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<test-module\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<maintainer\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<module\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<name\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<nhc98-options\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<other-modules\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<package-url\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<pkgconfig-depends\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<stability\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<subdir\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<synopsis\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<tag\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<tested-with\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<type\s*:/me=e-1
-syn match	cabalStatement	/^\c\s*\<version\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<author\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<branch\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<bug-reports\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<build-depends\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<build-tools\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<build-type\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<buildable\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<c-sources\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<cabal-version\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<category\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<cc-options\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<copyright\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<cpp-options\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<data-dir\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<data-files\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<default\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<description\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<executable\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<exposed\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<exposed-modules\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<extensions\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<extra-lib-dirs\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<extra-libraries\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<extra-source-files\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<extra-doc-files\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<extra-tmp-files\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<for example\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<frameworks\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<ghc-options\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<ghc-prof-options\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<ghc-shared-options\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<homepage\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<hs-source-dirs\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<hugs-options\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<include-dirs\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<includes\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<install-includes\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<ld-options\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<license\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<license-file\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<location\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<main-is\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<test-module\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<maintainer\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<module\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<name\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<nhc98-options\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<other-modules\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<package-url\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<pkgconfig-depends\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<stability\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<subdir\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<synopsis\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<tag\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<tested-with\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<type\s*:/me=e-1
+syn match       cabalStatement  /^\c\s*\<version\s*:/me=e-1
 
 " Define the default highlighting.
 " For version 5.7 and earlier: only when not done already
@@ -123,4 +123,3 @@ endif
 let b:current_syntax = "cabal"
 
 " vim: ts=8
-


### PR DESCRIPTION
The syntax file currently mixes spaces and tabs. This leads to alignment issues in contexts with different tab widths (such as GitHub).

You may prefer tabs rather than spaces. If so, you should use _tabs_ consistently. :)
